### PR TITLE
Changed max_precision to optional type

### DIFF
--- a/include/real/real.hpp
+++ b/include/real/real.hpp
@@ -2,6 +2,7 @@
 #define BOOST_REAL_REAL_HPP
 
 #include <iostream>
+#include <optional>
 #include <vector>
 #include <algorithm>
 #include <initializer_list>
@@ -88,7 +89,7 @@ namespace boost {
             /**
              * @brief Determines the maximum precision to use
              */
-            static unsigned int maximum_precision;
+            static std::optional<unsigned int> maximum_precision;
 
             /**
              * @author Laouen Mayal Louan Belloli
@@ -557,7 +558,9 @@ namespace boost {
              */
             unsigned int max_precision() const {
                 if (this->_maximum_precision == 0) {
-                    return boost::real::real::maximum_precision;
+                    if(!boost::real::real::maximum_precision)
+                        throw boost::real::undefined_max_precision_exception();
+                    return boost::real::real::maximum_precision.value();
                 }
 
                 return this->_maximum_precision;

--- a/include/real/real_algorithm.hpp
+++ b/include/real/real_algorithm.hpp
@@ -1,6 +1,9 @@
 #ifndef BOOST_REAL_REAL_ALGORITHM_HPP
 #define BOOST_REAL_REAL_ALGORITHM_HPP
 
+#include <optional>
+
+#include <real/real_exception.hpp>
 #include <real/interval.hpp>
 
 namespace boost {
@@ -29,7 +32,7 @@ namespace boost {
 
         public:
 
-            static unsigned int maximum_precision;
+            static std::optional<unsigned int> maximum_precision;
 
             /**
              * @author Laouen Mayal Louan Belloli
@@ -233,7 +236,9 @@ namespace boost {
              * @return an integer with the maximum allowed precision.
              */
             unsigned int max_precision() const {
-                return boost::real::real_algorithm::maximum_precision;
+                if(!boost::real::real_algorithm::maximum_precision)
+                    throw boost::real::undefined_max_precision_exception();
+                return boost::real::real_algorithm::maximum_precision.value();
             }
 
             /**
@@ -280,8 +285,10 @@ namespace boost {
              * @return a boost::real::real_algorithm::const_precision_iterator of the number.
              */
             const_precision_iterator cend() const {
+                if(!boost::real::real_algorithm::maximum_precision)
+                    throw boost::real::undefined_max_precision_exception();
                 const_precision_iterator it(this);
-                it.iterate_n_times(boost::real::real_algorithm::maximum_precision - 1);
+                it.iterate_n_times(boost::real::real_algorithm::maximum_precision.value() - 1);
                 return it;
             }
 

--- a/include/real/real_exception.hpp
+++ b/include/real/real_exception.hpp
@@ -32,6 +32,13 @@ namespace boost {
                 return "The string passed to construct the boost::real number is invalid";
             }
         };
+
+        struct undefined_max_precision_exception : public std::exception {
+
+            const char * what () const throw () override {
+                return "The maximum precision for boost::real has not been defined";
+            }
+        };
     }
 }
 

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -6,8 +6,8 @@
 #include <real/real_algorithm.hpp>
 #include <sstream>
 
-unsigned int boost::real::real::maximum_precision = 10;
-unsigned int boost::real::real_algorithm::maximum_precision = 10;
+std::optional<unsigned int> boost::real::real::maximum_precision = 10;
+std::optional<unsigned int> boost::real::real_algorithm::maximum_precision = 10;
 
 namespace Catch {
     template<>

--- a/test/real_algorithm_iterator_unit_test.cpp
+++ b/test/real_algorithm_iterator_unit_test.cpp
@@ -4,7 +4,29 @@
 #include <real/real_algorithm.hpp>
 #include <test_helpers.hpp>
 
+
+TEST_CASE("Check whether max precision for real::algorithm and real is declared") {
+
+    SECTION("Checking if real precision is declared") {
+        REQUIRE(boost::real::real::maximum_precision);
+    }
+
+    SECTION("Checking if real::algorithm precision is declared") {
+        REQUIRE(boost::real::real_algorithm::maximum_precision);
+    }
+    
+}
+
 TEST_CASE("Iterate boost::real_algorithm::const_precision_iterator until full precision is reached") {
+    
+    SECTION("Undefined maximum precision error") {
+        boost::real::real_algorithm::maximum_precision.reset(); //Simulating undefined maximum precision
+        boost::real::real_algorithm a([](unsigned int n) -> int { return 3; }, 0);
+        
+        CHECK_THROWS_AS(a.cend(), boost::real::undefined_max_precision_exception);
+
+        boost::real::real_algorithm::maximum_precision = 10;    //Redefining maximum precision for further tests
+    }
 
     SECTION("Positive numbers") {
 


### PR DESCRIPTION
Please review. Added the test for undefined precision in the real_algorithm_iterator_unit_test.cpp which I know is the wrong place to put it. If unnecessary, I'll remove it or please tell me where to add the test which shows the undefined precision error.